### PR TITLE
ci: tim-brown Update POMs for building of BOMs and migration to maven central publishing portal

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 17
           distribution: 'temurin'
@@ -41,5 +41,5 @@ jobs:
           ossrh_login: ${{ secrets.ossrh_login }}
           ossrh_pass: ${{ secrets.ossrh_pass }}
         run: |
-          mvn -B versions:set -DnewVersion="${{ github.event.release.tag_name }}"
+          mvn -B versions:set -DprocessAllModules -DnewVersion="${{ github.event.release.tag_name }}"
           mvn -B -s .mvn/settings.xml -P release deploy --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 17
         distribution: 'temurin'

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -25,6 +25,12 @@
             <username>${env.ossrh_login}</username>
             <password>${env.ossrh_pass}</password>
         </server>
+        <server>
+            <id>central</id>
+	    <!-- TODO: rename these to central_login/central_pass, and create secret variables -->
+            <username>${env.ossrh_login}</username>
+            <password>${env.ossrh_pass}</password>
+        </server>
     </servers>
 
     <profiles>

--- a/Bill of Materials/pom.xml
+++ b/Bill of Materials/pom.xml
@@ -13,6 +13,27 @@
     <description>Bill of Materials for Ocava Open-Source projects, can be used to facilitate dependency management</description>
     <url>https://github.com/ocadotechnology/Ocava</url>
 
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Ocado Simulation</name>
+            <organization>Ocado</organization>
+            <organizationUrl>https://github.com/ocadotechnology/Ocava</organizationUrl>
+        </developer>
+    </developers>
+
+    <properties>
+        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <!-- Bill of Materials: for Ocava Open-Source: only specify the modules produced by Ocava -->
@@ -44,6 +65,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <scm>
+        <connection>
+            scm:git:git@github.com:ocadotechnology/Ocava.git
+        </connection>
+        <developerConnection>
+            scm:git:git@github.com:ocadotechnology/Ocava.git
+        </developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/ocadotechnology/Ocava</url>
+    </scm>
 
     <build>
         <plugins>
@@ -79,24 +111,47 @@
         </plugins>
     </build>
 
-    <distributionManagement>
-        <repository>
-            <id>central</id>
-            <name>Ocada Cross Stream Releases</name>
-            <url>https://nexus.ocado.tech/repository/shared-maven-releases</url>
-        </repository>
-        <snapshotRepository>
-            <id>central</id>
-            <name>Ocada Cross Stream Snapshots</name>
-            <url>https://nexus.ocado.tech/repository/shared-maven-snapshots</url>
-            <uniqueVersion>false</uniqueVersion>
-        </snapshotRepository>
-        <site>
-            <id>ocado-maven-nexus</id>
-            <!-- The site is not deployed using maven, but site:stage requires the distribution information -->
-            <url>
-                http://fake/site
-            </url>
-        </site>
-    </distributionManagement>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation><activeByDefault>false</activeByDefault></activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- following instructions in:https://central.sonatype.org/publish/publish-portal-maven/ -->
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <!-- Ocado artifact will probably want this to be true -->
+                            <autoPublish>true</autoPublish>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <keyname>9272F1A5EF012E0ED15709CA7DA5608BAAD629A3</keyname>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/OcavaCore/pom.xml
+++ b/OcavaCore/pom.xml
@@ -9,6 +9,7 @@
         <artifactId>OcavaParent</artifactId>
         <version>0-SNAPSHOT</version>
     </parent>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/OcavaS3/pom.xml
+++ b/OcavaS3/pom.xml
@@ -9,6 +9,7 @@
         <artifactId>OcavaParent</artifactId>
         <version>0-SNAPSHOT</version>
     </parent>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/OcavaScenarioTest/pom.xml
+++ b/OcavaScenarioTest/pom.xml
@@ -9,6 +9,7 @@
         <artifactId>OcavaParent</artifactId>
         <version>0-SNAPSHOT</version>
     </parent>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/SuiteTestEngine/pom.xml
+++ b/SuiteTestEngine/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>SuiteTestEngine</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/TrafficLightSimulation/pom.xml
+++ b/TrafficLightSimulation/pom.xml
@@ -8,6 +8,7 @@
         <artifactId>OcavaParent</artifactId>
         <version>0-SNAPSHOT</version>
     </parent>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <!-- Maven Plugin versions -->
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-        <deploy.plugin.version>2.8.2</deploy.plugin.version>
+        <deploy.plugin.version>3.1.4</deploy.plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
 
         <!-- Extra rules for maven enforcer -->
@@ -87,7 +87,7 @@
         <spotbugs-annotations.version>4.9.3</spotbugs-annotations.version>
 
         <!-- OSSRH release plugins -->
-        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+	<central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
 
@@ -533,14 +533,14 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${nexus-staging-maven-plugin.version}</version>
+                        <!-- following instructions in:https://central.sonatype.org/publish/publish-portal-maven/ -->
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -581,18 +581,7 @@
                 <enabled>false</enabled>
             </snapshots>
             <name>bintray</name>
-            <url>https://dl.bintray.com/cbeust/maven</url>
+            <url>https://repo1.maven.org/maven2</url>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 </project>


### PR DESCRIPTION
Releases of Ocava have not been deployed to maven central for some time now. I have tried to fix this (frankly, so I can show off `Lookup`)... and discovered/fixed a few fun things.

From a branch on my fork, I have managed to draft a release, running the release action. It builds, tests, and invokes the `central-publishing-maven-plugin`. Pipeline fails with:
```
Error:  
Deployment 652c6230-fcf4-441e-a40c-c6578b32f74b failed
pkg:maven/com.ocadotechnology/ocava-open-source-bom@v17.18.0-exp.5?type=pom:
 - Invalid signature for file: ocava-open-source-bom-v17.18.0-exp.5.pom.asc
 - Namespace 'com.ocadotechnology' is not allowed
[... for each package...]
```
I think this is as far as I can go... my sonatype account won't allow me to publish `com.ocadotechnology` artifacts; and the signature is not going to be signing the wrong thing. So attached to this PR is the full error report; evidencing that I've got as far as I could before failure.

I acknowledge there is a fairly large number of critical design decisions I have made here; but I think you'll need to deal with the OSSRH &rarr; central migration sooner or later (and the deadline is rocking up pretty quick). OTOH, I'll take no offense if you just use this PR as _inspiration_. Good luck with it.

Note this is a `ci` semantic change, so it won't trigger a release; anyway, I guess that after reading the PR, you'll want to hand-hold this through.

`maven-release.yml`, `maven.yml`:
- there were whinges about the github actions setup scripts Ocava is using; updating them to version `@2` seems to have shut this up
- the BoM was not being `versions:set`, meaning that later in the build, `bom:(new-version)` isn't found: this is handled with `versions:set -DprocessAllModules`

Sonatype is migrating away from publishing via OSSRH to a new central publishing mechanism. I touch on it in one of my comments: https://central.sonatype.org/publish/publish-portal-maven, but this is by far not the extent of the reading. There are new secrets to be managed, and I think these will be global to `com.ocadotechnology`, I don't know how the internal open source community works there, but aligning on this might be worthwhile. So `.mvn/settings.xml` and maybe `pom.xml` and `BoM/pom.xml` will need better secrets (PGP, maybe, but probably not) management than I have here.

All `**/pom.xml`:
- in the new process, released artifacts need `<licences>`, `<developers>`, `<scm>` and `<name>`; the first three are inherited from parent `pom.xml`, but `<name>` had to be added to all POMs.

`.mvn/settings.xml`:
- the Sonatype tooling uses a server called `central`. I have added an entry here for `central`, but I'm still using `ossrh_login` ossrh_password` secret environment variables. You will need to manage this better. Leaving the two entries hopefully allows for a smoother migration, but you should be aiming at removing the `ossrh` entry.

Parent `pom.xml`:
- I thought, originally, for the previous point that this was something to not finding the artifact on _bintray_. Looking into it, the bintray service has been discontinued. That seems to have been well before Ocava releases stopped. But it couldn't have helped. I've left the repository identified as `bintray`, but pointed it at central... you _need_ a repository. I really think this needs thinking through a bit more thoroughly. But it seems to work.
- migrated from `nexus-staging-maven-plugin` to `central-publishing-maven-plugin`: distribution repositories are implicitly `central`, and need new credentials
- bumped `deploy.plugin.version`: some part of this process didn't seem to work with this
- removed `distributionManagement`: `central-publishing-maven-plugin` defines its own distribution targets (you can override them, but why?). It seems a bit odd to me that you are building an OSS artifact, then distributing it exclusively to your internal nexus. My suggestion is start with this configuration (distribute to central); let your nexus mirror pick up from central, and only if that is too slow/broken try to distribute directly to your nexus... I might be missing something.

`BoM/pom.xml`:
- I found that for some reason this stands separate to the rest of the modules in the project even though it's mentioned in the `pom.xml` -- why? I can't fathom... but AFAICT, it needs these two plugins mentioned for the `release` profile. The plugin definitions are identical to `pom.xml`
- removed `distributionManagement`: for the same reason as parent `pom.xml`
- again, `BoM/pom.xml` did not inherit the required metadata, so `<licences>`, `<developers>`, `<scm>` and `<name>` have been copied in from parent `pom.xml`